### PR TITLE
add asset_serial for barcode scanning to work

### DIFF
--- a/exporter/exporterCli.php
+++ b/exporter/exporterCli.php
@@ -376,6 +376,7 @@ function exportAssets()
                 'name' => $value['pcmake'],
                 'asset_type_name' => $main_asset['mainassetname'],
                 'customer_id' => $value['rs_cid'],
+                'asset_serial' => $value['rs_cid']
                 'properties' => $output
             )
         );


### PR DESCRIPTION
in PCRT it seems the simple customerid (primary key) is encoded into the barcode labels. If we just stick that value anywhere in the system it'll be searchable by barcode scanner in RS